### PR TITLE
Deprecated auto registration in favor of manual registration.

### DIFF
--- a/Gybs.sln
+++ b/Gybs.sln
@@ -23,6 +23,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{AF6723A5-FAF
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gybs.Logic.Operations", "src\Gybs.Logic.Operations\Gybs.Logic.Operations.csproj", "{33D3CD08-91BF-4BFA-A77D-9415A422FB6A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "root", "root", "{BED5983E-4FC0-45F1-8A2C-AF8FC596B31A}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ By default, library provides the `ServiceProviderOperationBus` which resolves th
 serviceCollection.AddGybs(builder => {
     builder.AddServiceProviderOperationBus();
     builder.AddOperationFactory();
-    builder.AddOperationHandlers();
+    builder.AddAttributeServices();
 );
 
 class DummyOperation : IOperation<string> {}
 
+[TransientService]
 class DummyOperationHandler : IOperationHandler<DummyOperation, string>
 {
     public async Task<IResult<string>> HandleAsync(DummyOperation operation)
@@ -115,9 +116,11 @@ Validation, available at [NuGet](https://www.nuget.org/packages/Gybs.Logic.Valid
 
 ```
 serviceCollection.AddGybs(builder => {
-    builder.AddValidation();
+    builder.AddValidator();
+    builder.AddAttributeServices();
 );
 
+[TransientService]
 class StringIsPresentRule : IValidationRule<string>
 {
     public async Task<IResult> ValidateAsync(string str)

--- a/src/Gybs.Data.Repositories/GybsServicesBuilderExtensions.cs
+++ b/src/Gybs.Data.Repositories/GybsServicesBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Gybs.DependencyInjection;
 using Gybs.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Reflection;
 
 namespace Gybs.Data.Repositories;
@@ -17,6 +18,7 @@ public static class GybsServicesBuilderExtensions
     /// <param name="serviceLifetime">The lifetime of registered service.</param>
     /// <param name="assembly">The assembly. If not provided, <see cref="Assembly.GetCallingAssembly"/> is used.</param>
     /// <returns>The builder.</returns>
+    [Obsolete("Given the possibility of multiple ServiceAttribute instances with different groups defined, usage of this method is discouraged.")]
     public static GybsServicesBuilder AddUnitOfWork(this GybsServicesBuilder servicesBuilder, ServiceLifetime serviceLifetime, Assembly? assembly = null)
     {
         ((IInfrastructure<IServiceCollection>)servicesBuilder).Instance
@@ -31,6 +33,7 @@ public static class GybsServicesBuilderExtensions
     /// <param name="serviceLifetime">The lifetime of registered service.</param>
     /// <param name="assembly">The assembly. If not provided, <see cref="Assembly.GetCallingAssembly"/> is used.</param>
     /// <returns>The builder.</returns>
+    [Obsolete("Given the possibility of multiple ServiceAttribute instances with different groups defined, usage of this method is discouraged.")]
     public static GybsServicesBuilder AddRepositories(this GybsServicesBuilder servicesBuilder, ServiceLifetime serviceLifetime, Assembly? assembly = null)
     {
         ((IInfrastructure<IServiceCollection>)servicesBuilder).Instance

--- a/src/Gybs.Logic.Cqrs/GybsServicesBuilderExtensions.cs
+++ b/src/Gybs.Logic.Cqrs/GybsServicesBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Gybs.DependencyInjection;
 using Gybs.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Reflection;
 
 namespace Gybs.Logic.Cqrs;
@@ -16,6 +17,7 @@ public static class GybsServicesBuilderExtensions
     /// <param name="servicesBuilder">The builder.</param>
     /// <param name="assembly">The assembly. If not provided, <see cref="Assembly.GetCallingAssembly"/> is used.</param>
     /// <returns>The builder.</returns>
+    [Obsolete("Given the possibility of multiple ServiceAttribute instances with different groups defined, usage of this method is discouraged.")]
     public static GybsServicesBuilder AddCqrsHandlers(this GybsServicesBuilder servicesBuilder, Assembly? assembly = null)
     {
         var serviceCollection = ((IInfrastructure<IServiceCollection>)servicesBuilder).Instance;

--- a/src/Gybs.Logic.Operations/GybsServicesBuilderExtensions.cs
+++ b/src/Gybs.Logic.Operations/GybsServicesBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Gybs.Logic.Operations.Factory.Internal;
 using Gybs.Logic.Operations.ServiceProvider;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
 using System.Reflection;
 
 namespace Gybs.Logic.Operations;
@@ -44,6 +45,7 @@ public static class GybsServicesBuilderExtensions
     /// <param name="servicesBuilder">The builder.</param>
     /// <param name="assembly">The assembly. If not provided, <see cref="Assembly.GetCallingAssembly"/> is used.</param>
     /// <returns>The builder.</returns>
+    [Obsolete("Given the possibility of multiple ServiceAttribute instances with different groups defined, usage of this method is discouraged.")]
     public static GybsServicesBuilder AddOperationInitializersForFactory(this GybsServicesBuilder servicesBuilder, Assembly? assembly = null)
     {
         ((IInfrastructure<IServiceCollection>)servicesBuilder).Instance
@@ -57,6 +59,7 @@ public static class GybsServicesBuilderExtensions
     /// <param name="servicesBuilder">The builder.</param>
     /// <param name="assembly">The assembly. If not provided, <see cref="Assembly.GetCallingAssembly"/> is used.</param>
     /// <returns>The builder.</returns>
+    [Obsolete("Given the possibility of multiple ServiceAttribute instances with different groups defined, usage of this method is discouraged.")]
     public static GybsServicesBuilder AddOperationHandlers(this GybsServicesBuilder servicesBuilder, Assembly? assembly = null)
     {
         var serviceCollection = ((IInfrastructure<IServiceCollection>)servicesBuilder).Instance;

--- a/src/Gybs.Logic.Validation/GybsServicesBuilderExtensions.cs
+++ b/src/Gybs.Logic.Validation/GybsServicesBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Gybs.Internal;
 using Gybs.Logic.Validation.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
 using System.Reflection;
 
 namespace Gybs.Logic.Validation;
@@ -13,11 +14,25 @@ namespace Gybs.Logic.Validation;
 public static class GybsServicesBuilderExtensions
 {
     /// <summary>
-    /// Adds a <see cref="IValidator"/> and all implementations of <see cref="IValidationRule{TValidationData}"/> which allows to aggregate validation rules.
+    /// Adds a <see cref="IValidator"/> default implementation which allows to aggregate validation rules.
+    /// </summary>
+    /// <param name="servicesBuilder">The builder.</param>
+    /// <returns>The builder.</returns>
+    public static GybsServicesBuilder AddValidator(this GybsServicesBuilder servicesBuilder)
+    {
+        var serviceCollection = ((IInfrastructure<IServiceCollection>)servicesBuilder).Instance;
+        serviceCollection.TryAddTransient<IValidator, Validator>();
+
+        return servicesBuilder;
+    }
+    
+    /// <summary>
+    /// Adds a <see cref="IValidator"/> default implementation and all implementations of <see cref="IValidationRule{TValidationData}"/> which allows to aggregate validation rules.
     /// </summary>
     /// <param name="servicesBuilder">The builder.</param>
     /// <param name="assembly">The assembly. If not provided, <see cref="Assembly.GetCallingAssembly"/> is used.</param>
     /// <returns>The builder.</returns>
+    [Obsolete("Given the possibility of multiple ServiceAttribute instances with different groups defined, usage of this method is discouraged.")]
     public static GybsServicesBuilder AddValidation(this GybsServicesBuilder servicesBuilder, Assembly? assembly = null)
     {
         var serviceCollection = ((IInfrastructure<IServiceCollection>)servicesBuilder).Instance;

--- a/tests/Gybs.Tests/Logic/Operations/ServiceProvider/ServiceProviderOperationBus.Tests.cs
+++ b/tests/Gybs.Tests/Logic/Operations/ServiceProvider/ServiceProviderOperationBus.Tests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Gybs.DependencyInjection.Services;
 using Gybs.Extensions;
 using Gybs.Logic.Operations;
 using Gybs.Logic.Operations.ServiceProvider;
@@ -13,6 +14,8 @@ namespace Gybs.Tests.Logic.Operations.ServiceProvider;
 
 public class ServiceProviderOperationBusTests
 {
+    private const string ServiceAttributeGroup = nameof(ServiceProviderOperationBusTests);
+    
     [Fact]
     public async Task ForRegisteredHandlerShouldHandleOperationWithoutData()
     {
@@ -44,7 +47,7 @@ public class ServiceProviderOperationBusTests
     {
         var logger = Substitute.For<ILogger<ServiceProviderOperationBus>>();
         var serviceProvider = new DefaultServiceProviderFactory().CreateServiceProvider(
-            new ServiceCollection().AddGybs(builder => builder.AddOperationHandlers())
+            new ServiceCollection().AddGybs(builder => builder.AddAttributeServices(group: ServiceAttributeGroup))
         );
 
         return new ServiceProviderOperationBus(logger, serviceProvider);
@@ -54,6 +57,7 @@ public class ServiceProviderOperationBusTests
     {
     }
 
+    [TransientService(ServiceAttributeGroup)]
     private class DummyOperationHandler : IOperationHandler<DummyOperation>
     {
         public Task<IResult> HandleAsync(DummyOperation operation) => Result.Success().ToCompletedTask();
@@ -64,6 +68,7 @@ public class ServiceProviderOperationBusTests
         public int InputData { get; set; }
     }
 
+    [TransientService(ServiceAttributeGroup)]
     private class DummyDataOperationHandler : IOperationHandler<DummyDataOperation, int>
     {
         private int _counter = 0;

--- a/tests/Gybs.Tests/Logic/Validation/Validator.EnsureValidAsync.Tests.cs
+++ b/tests/Gybs.Tests/Logic/Validation/Validator.EnsureValidAsync.Tests.cs
@@ -1,7 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using FluentAssertions;
+using Gybs.DependencyInjection.Services;
 using Gybs.Extensions;
 using Gybs.Logic.Validation;
 using Gybs.Logic.Validation.Internal;
@@ -9,12 +7,16 @@ using Gybs.Results;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Gybs.Tests.Logic.Validation;
 
 public class ValidatorEnsureValidAsyncTests
 {
+    private const string ServiceAttributeGroup = nameof(ValidatorEnsureValidAsyncTests);
+
     [Fact]
     public async Task ForSuccessfulValidationShouldPass()
     {
@@ -44,12 +46,13 @@ public class ValidatorEnsureValidAsyncTests
         var logger = Substitute.For<ILogger<Validator>>();
         var serviceProvider = new DefaultServiceProviderFactory().CreateServiceProvider(
             new ServiceCollection()
-                .AddGybs(builder => builder.AddValidation())
+                .AddGybs(builder => builder.AddValidator().AddAttributeServices(group: ServiceAttributeGroup))
         );
 
         return new Validator(logger, serviceProvider);
     }
 
+    [TransientService((ServiceAttributeGroup))]
     private class SucceededRule : IValidationRule<string>
     {
         public Task<IResult> ValidateAsync(string data)
@@ -58,6 +61,7 @@ public class ValidatorEnsureValidAsyncTests
         }
     }
 
+    [TransientService((ServiceAttributeGroup))]
     private class FailedRule : IValidationRule<string>
     {
         public Task<IResult> ValidateAsync(string data)

--- a/tests/Gybs.Tests/Logic/Validation/Validator.ValidateAsync.Tests.cs
+++ b/tests/Gybs.Tests/Logic/Validation/Validator.ValidateAsync.Tests.cs
@@ -1,6 +1,5 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using FluentAssertions;
+using Gybs.DependencyInjection.Services;
 using Gybs.Extensions;
 using Gybs.Logic.Validation;
 using Gybs.Logic.Validation.Internal;
@@ -8,12 +7,16 @@ using Gybs.Results;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Gybs.Tests.Logic.Validation;
 
 public class ValidatorValidateAsyncTests
 {
+    private const string ServiceAttributeGroup = nameof(ValidatorValidateAsyncTests);
+
     [Fact]
     public async Task ForSuccessfulValidationShouldSucceeded()
     {
@@ -47,12 +50,13 @@ public class ValidatorValidateAsyncTests
         var logger = Substitute.For<ILogger<Validator>>();
         var serviceProvider = new DefaultServiceProviderFactory().CreateServiceProvider(
             new ServiceCollection()
-                .AddGybs(builder => builder.AddValidation())
+                .AddGybs(builder => builder.AddValidator().AddAttributeServices(group: ServiceAttributeGroup))
         );
 
         return new Validator(logger, serviceProvider);
     }
 
+    [TransientService((ServiceAttributeGroup))]
     private class SucceededRule : IValidationRule<string>
     {
         public Task<IResult> ValidateAsync(string data)
@@ -61,6 +65,7 @@ public class ValidatorValidateAsyncTests
         }
     }
 
+    [TransientService((ServiceAttributeGroup))]
     private class FailedRule : IValidationRule<string>
     {
         public Task<IResult> ValidateAsync(string data)


### PR DESCRIPTION
`GybsServicesBuilderExtensions` extensions methods used to register
implementations of basic feature interfaces (such as handlers or
validation rules) automatically are now marked as obsolete. Manual
registration with `ServiceAttribute` and `group` parameter
approach is now preferred as it gives more flexibility and control.

Updated `README` to reflect the change.