### PR TITLE
Single type with multiple `IValidationRule<>` support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Base library, available at [NuGet](https://www.nuget.org/packages/Gybs), consist
 Example usage:
 ```
 Task<bool> IsPresent(string str) => str.IsPresent().ToCompletedTask();
+ValueTask<bool> IsPresent(string str) => str.IsPresent().ToCompletedValueTask();
 
 new [] { 1, 2, 3, 4 }.ForEach(e => Magic(e));
 await new [] { 1, 2, 3, 4 }.ForEachAsync(async e => await MagicAsync(e));
@@ -121,11 +122,18 @@ serviceCollection.AddGybs(builder => {
 );
 
 [TransientService]
-class StringIsPresentRule : IValidationRule<string>
+class ValueIsPresentRule : IValidationRule<string>, IValidationRule<RandomType>
 {
     public async Task<IResult> ValidateAsync(string str)
     {
         return result.IsPresent()
+            ? Result.Success()
+            : Result.Failure(null);
+    }
+    
+    public async Task<IResult> ValidateAsync(RandomType type)
+    {
+        return type is not null
             ? Result.Success()
             : Result.Failure(null);
     }
@@ -134,11 +142,15 @@ class StringIsPresentRule : IValidationRule<string>
 IValidator validator;
 
 var result = await validator
-    .Require<StringIsPresentRule>
+    .Require<ValueIsPresentRule>
         .WithOptions(o => o.StopIfFailed())
         .WithData("")
-    .Require<StringIsPresentRule>
-        .WithData(null)
+    .Require<ValueIsPresentRule>
+        .WithData(new RandomType())
+    .Require<ValueIsPresentRule>
+        .WithData((string)null)
+    .Require<ValueIsPresentRule>
+        .WithData((RandomType)null)
     .ValidateAsync();
 ```
 

--- a/src/Gybs.Logic.Validation/ConfiguredValidationRule.cs
+++ b/src/Gybs.Logic.Validation/ConfiguredValidationRule.cs
@@ -38,6 +38,7 @@ public static class ConfiguredValidationRuleExtensions
         if (rule is not ConfiguredValidationRule castedRule) throw new ArgumentException("Rule is not of ConfiguredValidationRule type.", nameof(rule));
 
         castedRule.Data = data;
+        castedRule.DataType = typeof(TData);
         return castedRule.Validator;
     }
 

--- a/tests/Gybs.Tests/Logic/Validation/Validator.EnsureValidAsync.Tests.cs
+++ b/tests/Gybs.Tests/Logic/Validation/Validator.EnsureValidAsync.Tests.cs
@@ -24,7 +24,8 @@ public class ValidatorEnsureValidAsyncTests
 
         await validator
             .Require<SucceededRule>().WithData(string.Empty)
-            .Require<SucceededRule>().WithData(string.Empty)
+            .Require<SucceededRule>().WithData((string)null!)
+            .Require<SucceededRule>().WithData(int.MinValue)
             .EnsureValidAsync();
     }
 
@@ -35,7 +36,9 @@ public class ValidatorEnsureValidAsyncTests
 
         Func<Task> action = async () => await validator
             .Require<SucceededRule>().WithData(string.Empty)
+            .Require<SucceededRule>().WithData(int.MinValue)
             .Require<FailedRule>().WithData(string.Empty)
+            .Require<FailedRule>().WithData(int.MinValue)
             .EnsureValidAsync();
 
         await action.Should().ThrowAsync<ValidationFailedException>();
@@ -53,18 +56,28 @@ public class ValidatorEnsureValidAsyncTests
     }
 
     [TransientService((ServiceAttributeGroup))]
-    private class SucceededRule : IValidationRule<string>
+    private class SucceededRule : IValidationRule<string>, IValidationRule<int>
     {
         public Task<IResult> ValidateAsync(string data)
+        {
+            return Result.Success().ToCompletedTask();
+        }
+
+        public Task<IResult> ValidateAsync(int data)
         {
             return Result.Success().ToCompletedTask();
         }
     }
 
     [TransientService((ServiceAttributeGroup))]
-    private class FailedRule : IValidationRule<string>
+    private class FailedRule : IValidationRule<string>, IValidationRule<int>
     {
         public Task<IResult> ValidateAsync(string data)
+        {
+            return Result.Failure(new ResultErrorsDictionary().Add("key", "value")).ToCompletedTask();
+        }
+
+        public Task<IResult> ValidateAsync(int data)
         {
             return Result.Failure(new ResultErrorsDictionary().Add("key", "value")).ToCompletedTask();
         }


### PR DESCRIPTION
Eliminated artifical limitation of `IValidator` which supported single implementation of `IValidationRule<>` per type only. Now method cache uses data type to store multiple infos of the single type.