### PR TITLE
Added support for immutable, record based operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,21 +76,32 @@ serviceCollection.AddGybs(builder => {
     builder.AddAttributeServices();
 );
 
-class DummyOperation : IOperation<string> {}
+class DummyOperation : IOperation<string> { ... }
+
+record MoreDummyOperation : IOperation<string> { ... }
 
 [TransientService]
-class DummyOperationHandler : IOperationHandler<DummyOperation, string>
+class DummyOperationHandler : IOperationHandler<DummyOperation, string>, IOperationHandler<MoreDummyOperation, string>
 {
     public async Task<IResult<string>> HandleAsync(DummyOperation operation)
     {
         return "success".ToSuccessfulResult();
     }
+    
+    public async Task<IResult<string>> HandleAsync(MoreDummyOperation operation)
+    {
+        return "success".ToSuccessfulResult();
+    }
 }
 
-IOperationFactory factory;
+IOperationFactory factory = ...;
 
-var result = await factory
-    .Create<DummyOperation>()
+var dummyResult = await factory
+    .Create<DummyOperation>(o => { o.Property = null; })
+    .HandleAsync();
+    
+var moreDummyResult = await factory
+    .Create<MoreDummyOperation>(o => o with { Property = null })
     .HandleAsync();
 ```
 

--- a/src/Gybs.Logic.Operations/Factory/IImmutableOperationInitializer.cs
+++ b/src/Gybs.Logic.Operations/Factory/IImmutableOperationInitializer.cs
@@ -1,0 +1,13 @@
+namespace Gybs.Logic.Operations.Factory;
+
+/// <summary>
+/// Represents a shared initialization logic for immutable operations.
+/// </summary>
+public interface IImmutableOperationInitializer
+{
+    /// <summary>
+    /// Creates a new operation using an existing one.
+    /// </summary>
+    /// <param name="operation">The operation to be used during the initialization.</param>
+    IOperationBase Initialize(IOperationBase operation);
+}

--- a/src/Gybs.Logic.Operations/Factory/IOperationFactory.cs
+++ b/src/Gybs.Logic.Operations/Factory/IOperationFactory.cs
@@ -42,4 +42,14 @@ public interface IOperationFactory
     /// <returns>Operation to handle.</returns>
     IOperationProxy<TOperation> UseExisting<TOperation>(TOperation operation, Action<TOperation> initializer)
         where TOperation : IOperationBase, new();
+
+    /// <summary>
+    /// Uses existing operation and initializes it.
+    /// </summary>
+    /// <param name="operation">Operation.</param>
+    /// <param name="factory">Factory method which which creates a new operation using an existing one. Invoked after <see cref="IOperationInitializer"/> implementations.</param>
+    /// <typeparam name="TOperation">Type implementing <see cref="IOperationBase"/>.</typeparam>
+    /// <returns>Operation to handle.</returns>
+    IOperationProxy<TOperation> UseExisting<TOperation>(TOperation operation, Func<TOperation, TOperation> factory)
+        where TOperation : IOperationBase, new();
 }


### PR DESCRIPTION
`OperationFactory` has a new overload of `UseExisting` method which allows to replace the instance of the operation instead of the modification.

Added `IImmutableOperationInitializer` which can create a new instance of the operation instead of the modification (as it is done with `IOperationInitializer`).